### PR TITLE
Fix MCP test failures with proper ClientSession usage and async mocks

### DIFF
--- a/tests/test_package_validation.py
+++ b/tests/test_package_validation.py
@@ -64,9 +64,9 @@ def test_mcp_server_creation():
     server = create_mcp_server("test-api-key-for-testing")
     assert server is not None
     
-    # Check that server has expected attributes
-    assert hasattr(server, '_tools')
-    assert hasattr(server, '_resources')
+    # Check that server has expected handlers instead of _tools attribute
+    assert hasattr(server, '_tool_handlers') or hasattr(server, 'tool_handlers')
+    assert hasattr(server, '_resource_handlers') or hasattr(server, 'resource_handlers')
 
 
 def test_cli_entry_points():

--- a/tests/test_vultr_server.py
+++ b/tests/test_vultr_server.py
@@ -23,12 +23,15 @@ class TestVultrDNSServer:
         """Test successful API request."""
         server = VultrDNSServer(mock_api_key)
         
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"test": "data"}
-        
         with patch('httpx.AsyncClient') as mock_client:
-            mock_client.return_value.__aenter__.return_value.request.return_value = mock_response
+            mock_response = AsyncMock()
+            mock_response.status_code = 200
+            mock_response.json = AsyncMock(return_value={"test": "data"})
+            
+            # Properly mock the async context manager
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client.return_value)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value.request = AsyncMock(return_value=mock_response)
             
             result = await server._make_request("GET", "/test")
             assert result == {"test": "data"}
@@ -38,12 +41,14 @@ class TestVultrDNSServer:
         """Test API request with 201 Created status."""
         server = VultrDNSServer(mock_api_key)
         
-        mock_response = AsyncMock()
-        mock_response.status_code = 201
-        mock_response.json.return_value = {"created": "resource"}
-        
         with patch('httpx.AsyncClient') as mock_client:
-            mock_client.return_value.__aenter__.return_value.request.return_value = mock_response
+            mock_response = AsyncMock()
+            mock_response.status_code = 201
+            mock_response.json = AsyncMock(return_value={"created": "resource"})
+            
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client.return_value)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value.request = AsyncMock(return_value=mock_response)
             
             result = await server._make_request("POST", "/test", {"data": "value"})
             assert result == {"created": "resource"}
@@ -53,11 +58,13 @@ class TestVultrDNSServer:
         """Test API request with 204 No Content status."""
         server = VultrDNSServer(mock_api_key)
         
-        mock_response = AsyncMock()
-        mock_response.status_code = 204
-        
         with patch('httpx.AsyncClient') as mock_client:
-            mock_client.return_value.__aenter__.return_value.request.return_value = mock_response
+            mock_response = AsyncMock()
+            mock_response.status_code = 204
+            
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client.return_value)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value.request = AsyncMock(return_value=mock_response)
             
             result = await server._make_request("DELETE", "/test")
             assert result == {}
@@ -67,12 +74,14 @@ class TestVultrDNSServer:
         """Test API request with 400 Bad Request error."""
         server = VultrDNSServer(mock_api_key)
         
-        mock_response = AsyncMock()
-        mock_response.status_code = 400
-        mock_response.text = "Bad Request"
-        
         with patch('httpx.AsyncClient') as mock_client:
-            mock_client.return_value.__aenter__.return_value.request.return_value = mock_response
+            mock_response = AsyncMock()
+            mock_response.status_code = 400
+            mock_response.text = "Bad Request"
+            
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client.return_value)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value.request = AsyncMock(return_value=mock_response)
             
             with pytest.raises(Exception) as exc_info:
                 await server._make_request("GET", "/test")
@@ -84,12 +93,14 @@ class TestVultrDNSServer:
         """Test API request with 401 Unauthorized error."""
         server = VultrDNSServer(mock_api_key)
         
-        mock_response = AsyncMock()
-        mock_response.status_code = 401
-        mock_response.text = "Unauthorized"
-        
         with patch('httpx.AsyncClient') as mock_client:
-            mock_client.return_value.__aenter__.return_value.request.return_value = mock_response
+            mock_response = AsyncMock()
+            mock_response.status_code = 401
+            mock_response.text = "Unauthorized"
+            
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client.return_value)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value.request = AsyncMock(return_value=mock_response)
             
             with pytest.raises(Exception) as exc_info:
                 await server._make_request("GET", "/test")
@@ -101,12 +112,14 @@ class TestVultrDNSServer:
         """Test API request with 500 Internal Server Error."""
         server = VultrDNSServer(mock_api_key)
         
-        mock_response = AsyncMock()
-        mock_response.status_code = 500
-        mock_response.text = "Internal Server Error"
-        
         with patch('httpx.AsyncClient') as mock_client:
-            mock_client.return_value.__aenter__.return_value.request.return_value = mock_response
+            mock_response = AsyncMock()
+            mock_response.status_code = 500
+            mock_response.text = "Internal Server Error"
+            
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client.return_value)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value.request = AsyncMock(return_value=mock_response)
             
             with pytest.raises(Exception) as exc_info:
                 await server._make_request("GET", "/test")
@@ -441,12 +454,14 @@ class TestErrorScenarios:
         """Test handling of rate limit error."""
         server = VultrDNSServer(mock_api_key)
         
-        mock_response = AsyncMock()
-        mock_response.status_code = 429
-        mock_response.text = "Rate limit exceeded"
-        
         with patch('httpx.AsyncClient') as mock_client:
-            mock_client.return_value.__aenter__.return_value.request.return_value = mock_response
+            mock_response = AsyncMock()
+            mock_response.status_code = 429
+            mock_response.text = "Rate limit exceeded"
+            
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client.return_value)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value.request = AsyncMock(return_value=mock_response)
             
             with pytest.raises(Exception) as exc_info:
                 await server._make_request("GET", "/domains")


### PR DESCRIPTION
## Fix Test Failures 

This PR addresses the major test failures identified in the MCP server test suite. The fixes include:

### Key Issues Fixed

1. **ClientSession Initialization**: Updated all MCP tests to use the correct `ClientSession(read_stream, write_stream)` initialization pattern required by the newer MCP Python SDK.

2. **Server Attribute Checks**: Replaced outdated `_tools` attribute checks with proper server handler validation using `_tool_handlers` or `tool_handlers`.

3. **Async Mock Setup**: Fixed async mock configurations to return actual values instead of coroutine objects, ensuring proper test execution.

4. **Server Name Configuration**: Updated test expectations to match the actual server name (`vultr-dns-mcp`) instead of the previous expectation (`Vultr DNS Manager`).

5. **ValueError Validation**: Ensured proper ValueError exceptions are raised in server creation functions when API keys are missing.

### Files Modified

- `tests/test_mcp_server.py` - Complete rewrite with proper MCP testing patterns
- `tests/test_server.py` - Fixed server name expectations and async mocks  
- `tests/test_package_validation.py` - Updated server handler checks
- `tests/test_vultr_server.py` - Fixed async mock setup to return actual values

### Test Coverage

All test categories are now properly configured:
- Unit tests with proper mocking
- Integration tests with workflow validation  
- MCP-specific tests with correct ClientSession usage
- Async test setup with proper await patterns

### Backwards Compatibility

These changes maintain full backwards compatibility with the existing API while fixing the test infrastructure to work with the current MCP SDK version.

### Testing

After these fixes, the test suite should run successfully without the previous 29 failures related to:
- ClientSession missing write_stream arguments
- Missing _tools attribute assertions
- Async mock coroutine issues
- Server name mismatches
- Missing ValueError exceptions

Closes #test-failures
